### PR TITLE
Add support for loop and autoplay attributes for videos, add random_sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Whether using the editor or yaml, the following configurations can be used:
 | slideshow_timer | integer | **Optional** | If present and greater than 0, will automatically advance the gallery after the provided number of seconds have passed.
 | video_autoplay | boolean | **Optional** | Enables the autoplay attribute for the main video in the gallery.
 | video_loop | boolean | **Optional** | Enables the loop attribute for the main video in the gallery.
-| video_muted | boolean | **Optional** | Enables the muted attribute for the main video in the gallery.
 | parsed_date_sort | boolean | **Optional** | Whether to use the date parsed using file_name_format in order to sort the items.  Use this to ensure sorting by date if the source is not properly sorted.  The default is false.
 | reverse_sort | boolean | **Optional** | Whether to sort the items with the newest first.  The default is true.
 | show_reload | boolean | **Optional** | Shows a reload link to allow manually triggering a reload of images/videos.  The default is false.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Whether using the editor or yaml, the following configurations can be used:
 | caption_format | string | **Optional** | The format of the caption (see below).  Used in combination with file_name_format.
 | caption_leading_zeros | boolean | **Optional** | Whether to include leading zeros in the caption month, day, and hours.  The default is false.
 | slideshow_timer | integer | **Optional** | If present and greater than 0, will automatically advance the gallery after the provided number of seconds have passed.
-| video_autoplay | boolean | **Optional** | Enables the autoplay attribute for the videos in the dashboard
-| video_loop | boolean | **Optional** | Enables the loop attribute for the videos in the dashboard
+| video_autoplay | boolean | **Optional** | Enables the autoplay attribute for the main video in the gallery.
+| video_loop | boolean | **Optional** | Enables the loop attribute for the main video in the gallery.
+| video_muted | boolean | **Optional** | Enables the muted attribute for the main video in the gallery.
 | parsed_date_sort | boolean | **Optional** | Whether to use the date parsed using file_name_format in order to sort the items.  Use this to ensure sorting by date if the source is not properly sorted.  The default is false.
 | reverse_sort | boolean | **Optional** | Whether to sort the items with the newest first.  The default is true.
 | show_reload | boolean | **Optional** | Shows a reload link to allow manually triggering a reload of images/videos.  The default is false.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Whether using the editor or yaml, the following configurations can be used:
 | video_loop | boolean | **Optional** | Enables the loop attribute for the main video in the gallery.
 | parsed_date_sort | boolean | **Optional** | Whether to use the date parsed using file_name_format in order to sort the items.  Use this to ensure sorting by date if the source is not properly sorted.  The default is false.
 | reverse_sort | boolean | **Optional** | Whether to sort the items with the newest first.  The default is true.
+| random_sort | boolean | **Optional** | Whether to sort the items randomly.  The default is false.
 | show_reload | boolean | **Optional** | Shows a reload link to allow manually triggering a reload of images/videos.  The default is false.
 
 ### Media Source

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Whether using the editor or yaml, the following configurations can be used:
 | caption_format | string | **Optional** | The format of the caption (see below).  Used in combination with file_name_format.
 | caption_leading_zeros | boolean | **Optional** | Whether to include leading zeros in the caption month, day, and hours.  The default is false.
 | slideshow_timer | integer | **Optional** | If present and greater than 0, will automatically advance the gallery after the provided number of seconds have passed.
+| video_autoplay | boolean | **Optional** | Enables the autoplay attribute for the videos in the dashboard
+| video_loop | boolean | **Optional** | Enables the loop attribute for the videos in the dashboard
 | parsed_date_sort | boolean | **Optional** | Whether to use the date parsed using file_name_format in order to sort the items.  Use this to ensure sorting by date if the source is not properly sorted.  The default is false.
 | reverse_sort | boolean | **Optional** | Whether to sort the items with the newest first.  The default is true.
 | show_reload | boolean | **Optional** | Shows a reload link to allow manually triggering a reload of images/videos.  The default is false.

--- a/gallery-card.js
+++ b/gallery-card.js
@@ -36,7 +36,7 @@ class GalleryCard extends LitElement {
                   ></hui-image>` :
                 this._isImageExtension(this._currentResource().extension) ?
                 html`<img @click="${ev => this._popupImage(ev)}" src="${this._currentResource().url}"/>` :
-                html`<video controls ?loop=${this.config.video_loop} ?autoplay=${this.config.video_autoplay} src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
+                html`<video controls ?loop=${this.config.video_loop} ?autoplay=${this.config.video_autoplay} ?muted=${this.config.video_muted} src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
               }
               <figcaption>${this._currentResource().caption} 
                 ${this._isImageExtension(this._currentResource().extension) ?
@@ -964,6 +964,10 @@ class GalleryCardEditor extends LitElement {
 
   get _videoAutoplay() {
     return this._config.video_autoplay ?? false;
+  }
+
+  get _videoMuted() {
+    return this._config.video_muted ?? false;
   }
 
   formatDate2Digits(str, zeroPad) {

--- a/gallery-card.js
+++ b/gallery-card.js
@@ -36,7 +36,7 @@ class GalleryCard extends LitElement {
                   ></hui-image>` :
                 this._isImageExtension(this._currentResource().extension) ?
                 html`<img @click="${ev => this._popupImage(ev)}" src="${this._currentResource().url}"/>` :
-                html`<video controls src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
+                html`<video controls ?loop=${this.config.video_loop} ?autoplay=${this.config.video_autoplay} src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
               }
               <figcaption>${this._currentResource().caption} 
                 ${this._isImageExtension(this._currentResource().extension) ?
@@ -956,6 +956,14 @@ class GalleryCardEditor extends LitElement {
 
   get _showReload() {
     return this._config.show_reload ?? false;
+  }
+
+  get _videoLoop() {
+    return this._config.video_loop ?? false;
+  }
+
+  get _videoAutoplay() {
+    return this._config.video_autoplay ?? false;
   }
 
   formatDate2Digits(str, zeroPad) {

--- a/gallery-card.js
+++ b/gallery-card.js
@@ -36,7 +36,7 @@ class GalleryCard extends LitElement {
                   ></hui-image>` :
                 this._isImageExtension(this._currentResource().extension) ?
                 html`<img @click="${ev => this._popupImage(ev)}" src="${this._currentResource().url}"/>` :
-                html`<video controls ?loop=${this.config.video_loop} ?autoplay=${this.config.video_autoplay} ?muted=${this.config.video_muted} src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
+                html`<video controls ?loop=${this.config.video_loop} ?autoplay=${this.config.video_autoplay} src="${this._currentResource().url}#t=0.1" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._startVideo(ev)}"></video>`
               }
               <figcaption>${this._currentResource().caption} 
                 ${this._isImageExtension(this._currentResource().extension) ?
@@ -964,10 +964,6 @@ class GalleryCardEditor extends LitElement {
 
   get _videoAutoplay() {
     return this._config.video_autoplay ?? false;
-  }
-
-  get _videoMuted() {
-    return this._config.video_muted ?? false;
   }
 
   formatDate2Digits(str, zeroPad) {

--- a/gallery-card.js
+++ b/gallery-card.js
@@ -310,6 +310,7 @@ class GalleryCard extends LitElement {
     const captionLeadingZeros = this.config.caption_leading_zeros ?? false;
     const parsedDateSort = this.config.parsed_date_sort ?? false;
     const reverseSort = this.config.reverse_sort ?? true;
+    const randomSort = this.config.random_sort ?? false;
 
     this.config.entities.forEach(entity => {
       var entityId;
@@ -360,6 +361,15 @@ class GalleryCard extends LitElement {
         }
         else {
           this.resources.sort(function (x, y) { return x.date - y.date; });
+        }
+      }
+
+      if (randomSort) {
+        for(var i = this.resources.length - 1; i > 0; i--) {
+          var r = Math.floor(Math.random() * (i + 1) );
+          if(i != r) {
+            [this.resources[i], this.resources[r]] = [this.resources[r], this.resources[i]];
+          }
         }
       }
 


### PR DESCRIPTION
Hello, and thank you for this awesome project!

### New flags for video attributes
I have added a couple of configuration flags that I needed in my installation, to control the `loop` and `autoplay` attributes for videos, and thought this change may be useful also for others.

A couple of notes:
- I wasn't able to modify the editor pop up interface to integrate these two flags, but of course they still work when changed from the code editor.
- I also tried adding a control for the `muted` attribute at first (or the `volume="0"` trick), but it turned out to not be trivial since that attribute [doesn't seem to work in certain cases](https://stackoverflow.com/questions/14111917/html5-video-muted-but-still-playing), including this card.

Resolves https://github.com/TarheelGrad1998/gallery-card/issues/28

### New flag: random_sort

In addition, i also implemented a `random_sort` flag, for use cases such as e.g. photoframes in which you may prefer variety.