### PR TITLE
Add option to disable preloading of videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Whether using the editor or yaml, the following configurations can be used:
 | video_autoplay | boolean | **Optional** | Enables the autoplay attribute for the main video in the gallery.  The default is false.
 | video_loop | boolean | **Optional** | Enables the loop attribute for the main video in the gallery.  The default is false.
 | video_muted | boolean | **Optional** | Mutes all videos in the gallery.  The default is false.
+| video_preload | boolean | **Optional** | Enables preloading and displaying of the preview image of all videos in the gallery. If disabled a static icon will be displayed instead. The default is true.
 | parsed_date_sort | boolean | **Optional** | Whether to use the date parsed using file_name_format in order to sort the items.  Use this to ensure sorting by date if the source is not properly sorted.  The default is false.
 | reverse_sort | boolean | **Optional** | Whether to sort the items with the newest first.  The default is true.
 | random_sort | boolean | **Optional** | Whether to sort the items randomly.  The default is false.

--- a/gallery-card.js
+++ b/gallery-card.js
@@ -65,7 +65,9 @@ class GalleryCard extends LitElement {
                         ></hui-image>` :
                       this._isImageExtension(resource.extension) ?
                       html`<img class="lzy_img" src="/local/community/gallery-card/placeholder.jpg" data-src="${resource.url}"/>` :
-					            html`<video preload="none" data-src="${resource.url}" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._downloadNextMenuVideo()}"></video>`
+                        (this.config.video_preload ?? true) ?
+                        html`<video preload="none" data-src="${resource.url}" @loadedmetadata="${ev => this._videoMetadataLoaded(ev)}" @canplay="${ev => this._downloadNextMenuVideo()}"></video>` :
+                          html`<center><div class="lzy_img"><ha-icon id="play" icon="mdi:movie-play-outline"></ha-icon></div></center>`
                     }
                     <figcaption>${resource.caption} <span class="duration"></span></figcaption>
                     </figure>


### PR DESCRIPTION
In some scenarios the bandwidth is limited and preloading all the items in the menu takes a lot of time, for example when using a cellular connection. 
This might take more time to load the UI and eat up a lot of bandwidth (depending on the size of the videos). The preview might even not be needed at all for some users (as in my case).

With an option 'video_preload: false' a static icon can be displayed instead of the preview image and speed up the page loading. This is not a breaking change as nothing changes if the option is not present in the config.

Example lovelace card:
![image](https://user-images.githubusercontent.com/70015952/233983489-320cf5ca-0347-4784-b8fa-4333c949003d.png)

